### PR TITLE
Use eclipse-temurin with jib

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -178,6 +178,9 @@
         <artifactId>jib-maven-plugin</artifactId>
         <version>3.1.4</version>
         <configuration>
+          <from>
+            <image>eclipse-temurin:17-focal</image>
+          </from>
           <to>
             <image>registry.heroku.com/cw-magidash-api/web</image>
             <auth>


### PR DESCRIPTION
By default jib uses distroless which hasn't published java 17 docker images yet. Use a eclipse-temurin as an alternative.